### PR TITLE
Handle error if opn can't find a browser

### DIFF
--- a/lib/server/dev.ts
+++ b/lib/server/dev.ts
@@ -38,10 +38,14 @@ export const getHotReloadMiddleware: HotReloadMiddleware = (log, buildConfig) =>
     return [dev, hot]
 }
 
-export const openBrowser = (port: number) => {
+export const openBrowser = async (log: Logger, port: number) => {
     if (process.env.NODE_ENV === 'test') {
         return
     }
 
-    opn(`http://localhost:${port}`)
+    try {
+        await opn(`http://localhost:${port}`)
+    } catch (e) {
+        log.warn(e, 'Opening browser failed')
+    }
 }

--- a/lib/watch/server.ts
+++ b/lib/watch/server.ts
@@ -60,7 +60,7 @@ const watchServer = (log: Logger, buildConfig: BuildConfig) =>
 
         const watching = serverCompiler.watch({}, () => {
             if (!devServer) {
-                setTimeout(() => openBrowser(hostPort), 2000)
+                setTimeout(() => openBrowser(log, hostPort), 2000)
             }
             devServer = restartServer(buildConfig, devServerPort, buildConfig.BASE, devServer)
 


### PR DESCRIPTION
Had a situation where this was running inside a docker container, opn fails to open a browser window in dev mode and it throws/exits. This PR catches and logs that error.