### PR TITLE
Adds prebody page tag to insert content before root element

### DIFF
--- a/lib/runtime/server/middleware/default-html-middleware.ts
+++ b/lib/runtime/server/middleware/default-html-middleware.ts
@@ -78,6 +78,7 @@ export const getDefaultHtmlMiddleware = (log: Logger, runtimeConfig: RuntimeConf
             head: undefined,
             pageTags: {
                 body: getBodyAssets(buildAssets),
+                preBody: [],
                 head: getHeadAssets(buildAssets),
             },
             renderResult: '',

--- a/lib/runtime/server/ssr/create-middleware.ts
+++ b/lib/runtime/server/ssr/create-middleware.ts
@@ -28,13 +28,11 @@ export interface RenderContext<SSRRequestProps = object> {
     promiseTracker: PromiseTracker
 }
 
-export type RenderApp<SSRRequestProps extends object> = (
-    params: {
-        log: Logger
-        context: RenderContext<SSRRequestProps>
-        req: Request
-    },
-) => JSX.Element
+export type RenderApp<SSRRequestProps extends object> = (params: {
+    log: Logger
+    context: RenderContext<SSRRequestProps>
+    req: Request
+}) => JSX.Element
 
 export interface RenderHtmlParams<SSRRequestProps extends object, RenderResult> {
     head: HelmetData | undefined
@@ -47,14 +45,12 @@ export type RenderHtml<SSRRequestProps extends object, RenderResult> = (
     params: RenderHtmlParams<SSRRequestProps, RenderResult>,
 ) => string
 
-export type CreatePageTags<SSRRequestProps> = (
-    options: {
-        buildAssets: Assets
-        helmetTags: string[]
-        stateTransfers: PageTag[]
-        renderContext: RenderContext<SSRRequestProps>
-    },
-) => PageTags
+export type CreatePageTags<SSRRequestProps> = (options: {
+    buildAssets: Assets
+    helmetTags: string[]
+    stateTransfers: PageTag[]
+    renderContext: RenderContext<SSRRequestProps>
+}) => PageTags
 
 export interface ServerSideRenderMiddlewareOptions<SSRRequestProps extends object, RenderResult> {
     app: Express & { log: Logger }
@@ -157,6 +153,7 @@ export const createSsrMiddleware = <SSRRequestProps extends object, RenderResult
                 ? options.createPageTags({ buildAssets, helmetTags, stateTransfers, renderContext })
                 : {
                       body: [...getBodyAssets(buildAssets)],
+                      preBody: [],
                       head: [
                           ...helmetTags.map(tag => ({ tag })),
                           ...getHeadAssets(buildAssets),

--- a/lib/runtime/server/ssr/full-render.tsx
+++ b/lib/runtime/server/ssr/full-render.tsx
@@ -31,6 +31,7 @@ export interface PageTag {
 
 export interface PageTags {
     head: PageTag[]
+    preBody: PageTag[]
     body: PageTag[]
 }
 

--- a/lib/runtime/server/ssr/helpers/render-html.ts
+++ b/lib/runtime/server/ssr/helpers/render-html.ts
@@ -1,4 +1,7 @@
 import { RenderHtml } from '../create-middleware'
+import { PageTag } from '../full-render'
+
+const returnTag = (pageTag: PageTag) => pageTag.tag
 
 export const renderHtml: RenderHtml<any, string> = ({ pageTags, renderResult }) => {
     return `<!DOCTYPE html>
@@ -7,13 +10,12 @@ export const renderHtml: RenderHtml<any, string> = ({ pageTags, renderResult }) 
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        ${pageTags.head.map(headAsset => headAsset.tag).join(`
-        `)}
+        ${pageTags.head.map(returnTag).join(``)}
     </head>
     <body>
+        ${pageTags.preBody.map(returnTag).join(``)}
         <div id="root">${renderResult}</div>
-        ${pageTags.body.map(bodyAsset => bodyAsset.tag).join(`
-        `)}
+        ${pageTags.body.map(returnTag).join(``)}
     </body>
 </html>`
 }


### PR DESCRIPTION
We have run into the need to be able to insert content before the root
element or another way of thinking about it, as the first element in the
body.

This new prop is called preBody and is by default empty but you can add
html content as needed. Tests have been added in ssr.test.tsx to test all
of the page tags.