### PR TITLE
Add support for additional client entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,7 +170,7 @@ build-stats.csv
 *.tgz
 test-dist
 
-tsconfig.tsbuildinfo
+*.tsbuildinfo
 
 #cache-loader & validation inside this folder
 .build-cache

--- a/examples/simple-ssr/client/extra.tsx
+++ b/examples/simple-ssr/client/extra.tsx
@@ -1,0 +1,1 @@
+console.log('extra entry!')

--- a/examples/simple-ssr/config/config.js
+++ b/examples/simple-ssr/config/config.js
@@ -2,5 +2,8 @@
 module.exports = {
     default: {
         TS_CONFIG_SERVER: 'examples/simple-ssr/tsconfig.server.json',
+        ADDITIONAL_CIENT_ENTRIES: {
+            additional: 'examples/simple-ssr/client/extra.tsx',
+        },
     },
 }

--- a/lib/config/webpack.client.ts
+++ b/lib/config/webpack.client.ts
@@ -48,6 +48,10 @@ const clientBaseConfig: CreateWebpackConfig = options => {
         main: mainEntry,
     }
 
+    if (options.buildConfig.ADDITIONAL_CIENT_ENTRIES) {
+        Object.assign(entry, options.buildConfig.ADDITIONAL_CIENT_ENTRIES)
+    }
+
     const plugins = getPlugins(options.buildConfig)
     const resolvePlugins: webpack.ResolvePlugin[] = []
 

--- a/lib/runtime/server.ts
+++ b/lib/runtime/server.ts
@@ -44,6 +44,10 @@ export interface BuildConfig {
     /** entry file for the client */
     CLIENT_ENTRY: string
 
+    ADDITIONAL_CIENT_ENTRIES?: {
+        [name: string]: string[]
+    }
+
     /** file for client polyfills if needed */
     CLIENT_POLYFILLS: string | false
 


### PR DESCRIPTION
Useful for if you have routes which render something different than the main entry point. Essentially allowing supporting different apps on different routes