### PR TITLE
Add yarn lock, npm lock and babel config files into validation cache …

### DIFF
--- a/.changeset/poor-actors-rule.md
+++ b/.changeset/poor-actors-rule.md
@@ -1,0 +1,5 @@
+---
+'project-watchtower': major
+---
+
+Expanded build cache files to cache bust when dependencies or babel config changes

--- a/lib/bin/build.ts
+++ b/lib/bin/build.ts
@@ -10,7 +10,7 @@ import { writeFile, existsSync } from '../runtime/util/fs'
 import { BuildEnvironment, BuildParam, BuildTarget } from '../types'
 import { webpackPromise } from '../util/webpack'
 import { getMd5, setupWithBuildInfo, validateCache, ValidationItem } from './cache-validator'
-import { getBabelConfigFile, getTsConfigFile } from 'lib/config/ts-loader-config'
+import { getBabelConfigFile, getTsConfigFile } from '../config/ts-loader-config'
 
 export function smp(buildConfig: BuildConfig, webpackConfig: webpack.Configuration) {
     const smpPlugin = new SpeedMeasurePlugin()

--- a/lib/bin/cache-validator.ts
+++ b/lib/bin/cache-validator.ts
@@ -7,7 +7,7 @@ import { Logger } from 'typescript-log'
 import { promisify } from 'util'
 import { BuildEnvironment, BuildTarget } from '../../lib/types'
 
-type ValidationItem =
+export type ValidationItem =
     | {
           isFile: true
           filePath: string

--- a/lib/config/ts-loader-config.ts
+++ b/lib/config/ts-loader-config.ts
@@ -23,10 +23,7 @@ export function getTypeScriptWebpackRule(
     options: CreateWebpackConfigOptions,
     buildTarget: BuildTarget,
 ): webpack.RuleSetRule {
-    const configFile =
-        (buildTarget === 'server'
-            ? options.buildConfig.TS_CONFIG_SERVER
-            : options.buildConfig.TS_CONFIG_CLIENT) || 'tsconfig.json'
+    const configFile = getTsConfigFile(buildTarget, options.buildConfig)
 
     options.log.info(`Target ${buildTarget} using ts config file: ${configFile}`)
 
@@ -69,6 +66,13 @@ export function getTypeScriptWebpackRule(
             ? [cacheLoader(options.cacheDirectory), babelLoader, tsLoader]
             : [babelLoader, tsLoader],
     }
+}
+
+export function getTsConfigFile(buildTarget: string, buildConfig: BuildConfig) {
+    return (
+        (buildTarget === 'server' ? buildConfig.TS_CONFIG_SERVER : buildConfig.TS_CONFIG_CLIENT) ||
+        'tsconfig.json'
+    )
 }
 
 export function getBabelConfigFile(buildTarget: BuildTarget, buildConfig: BuildConfig) {

--- a/lib/config/ts-loader-config.ts
+++ b/lib/config/ts-loader-config.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import webpack from 'webpack'
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'
-import { CreateWebpackConfigOptions } from '../runtime/server'
+import { CreateWebpackConfigOptions, BuildConfig } from '../runtime/server'
 import { BuildTarget } from '../types'
 
 const disableCaching = String(process.env.BUILD_CACHE_DISABLED).toLowerCase() === 'true'
@@ -46,19 +46,7 @@ export function getTypeScriptWebpackRule(
     }
     resolvePlugins.push(new TsconfigPathsPlugin(tsConfigPathsPluginConfig))
 
-    const babelConfigFile =
-        (buildTarget === 'server'
-            ? options.buildConfig.BABEL_CONFIG_SERVER
-            : options.buildConfig.BABEL_CONFIG_CLIENT) || '.babelrc'
-
-    let babelConfig: string | undefined = path.resolve(options.buildConfig.BASE, babelConfigFile)
-
-    if (!fs.existsSync(babelConfig)) {
-        babelConfig = path.resolve(process.cwd(), babelConfigFile)
-        if (!fs.existsSync(babelConfig)) {
-            babelConfig = undefined
-        }
-    }
+    const babelConfig: string | undefined = getBabelConfigFile(buildTarget, options.buildConfig)
 
     if (babelConfig) {
         options.log.info(`Using babel config: ${babelConfig}`)
@@ -81,4 +69,22 @@ export function getTypeScriptWebpackRule(
             ? [cacheLoader(options.cacheDirectory), babelLoader, tsLoader]
             : [babelLoader, tsLoader],
     }
+}
+
+export function getBabelConfigFile(buildTarget: BuildTarget, buildConfig: BuildConfig) {
+    const babelConfigFile =
+        (buildTarget === 'server'
+            ? buildConfig.BABEL_CONFIG_SERVER
+            : buildConfig.BABEL_CONFIG_CLIENT) || '.babelrc'
+
+    let babelConfig: string | undefined = path.resolve(buildConfig.BASE, babelConfigFile)
+
+    if (!fs.existsSync(babelConfig)) {
+        babelConfig = path.resolve(process.cwd(), babelConfigFile)
+        if (!fs.existsSync(babelConfig)) {
+            babelConfig = undefined
+        }
+    }
+
+    return babelConfig
 }


### PR DESCRIPTION
…items

This will ensure the cache is not used when dependencies or babel config change