### PR TITLE
FEATURE: Migrate to Complete Package Versions

### DIFF
--- a/.changeset/fuzzy-rings-sit.md
+++ b/.changeset/fuzzy-rings-sit.md
@@ -1,0 +1,11 @@
+---
+'bundle-splitting-using-loadable': minor
+'emotion-css-in-js': minor
+'ssr-with-data-loading-using-redux': minor
+'ssr-with-sass': minor
+'@project-watchtower/cli': minor
+'@project-watchtower/runtime': minor
+'@project-watchtower/server': minor
+---
+
+Marked all packages as safe to use with Typescript 5.4 & Node 18 by a complete minor version bump.

--- a/examples/bundle-splitting/package.json
+++ b/examples/bundle-splitting/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bundle-splitting-using-loadable",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.0",
     "description": "",
     "main": "dist/server.js",
     "license": "MIT",

--- a/examples/emotion-css-in-js/package.json
+++ b/examples/emotion-css-in-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "emotion-css-in-js",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.0",
     "main": "dist/server.js",
     "license": "MIT",
     "private": true,

--- a/examples/ssr-with-data-loading-using-redux/package.json
+++ b/examples/ssr-with-data-loading-using-redux/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ssr-with-data-loading-using-redux",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.0",
     "main": "dist/server.js",
     "license": "MIT",
     "private": true,

--- a/examples/ssr-with-sass/package.json
+++ b/examples/ssr-with-sass/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ssr-with-sass",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.0",
     "description": "",
     "scripts": {
         "build": "node ../../dist/cjs/bin/index.js build"

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
         "@types/webpack-merge": "^4.1.5",
         "@typescript-eslint/eslint-plugin": "^7.12.0",
         "@typescript-eslint/parser": "^7.12.0",
+        "esbuild-loader": "^4.2.0",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-config-wanews": "^2.2.0",
@@ -113,5 +114,6 @@
         "util": "^0.12.5",
         "webpack": "^5.0.0"
     },
-    "version": "0.0.0"
+    "version": "0.0.0",
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@project-watchtower/cli",
-    "version": "2.0.0-beta.22",
+    "version": "2.0.0",
     "license": "MIT",
     "author": {
         "name": "Seven West Media"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
         "webpack-hot-middleware": "^2.26.0",
         "webpack-merge": "^5.10.0"
     },
-    "devDependencies": {},
     "peerDependencies": {
         "webpack": "^5.0.0"
     }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@project-watchtower/runtime",
-    "version": "2.0.0-beta.12",
+    "version": "2.0.0",
     "license": "MIT",
     "author": {
         "name": "Seven West Media"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@project-watchtower/server",
-    "version": "2.0.0-beta.15",
+    "version": "2.0.0",
     "license": "MIT",
     "author": {
         "name": "Seven West Media"


### PR DESCRIPTION
## What

Migrate all PWT packages to a non beta stage, in confirmation that it's all working with Node18

## Why

As apart of news-mono update

## How

Manually removed versions and updated ran `yarn changeset`